### PR TITLE
removed django-cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 The information for each release is divided into the following chapters:
 
-### IMPORTANT
+#### IMPORTANT
 These changes might not be backward compatible and require updating existing code. (If not applied correctly your update will fail)
 ###### SETTINGS
 change your setting.py accordingly
@@ -13,14 +13,18 @@ changes to urls.py
 new or changed requirements
 ###### DATA MIGRATIONS
 stuff to migrate by hand or create data migrations manually
-### NEW
+#### NEW
 new features or plugins
-### FIXES
+#### FIXES
 general bugfixes
 
+## v2.3.1
+#### IMPORTANT
+###### REQUIREMENTS
+- removed django-cleanup==2.1.0
 
 ## v2.3.0
-### IMPORTANT
+#### IMPORTANT
 - UPDATE REQUIRED: [allink-core-static v2.3.0](https://github.com/allink/allink-core-static/blob/v2.3.0/CHANGELOG.md)
 - added 'javascript-catalog' so you need to update our urls.py with
 ```python
@@ -32,34 +36,34 @@ from django.views.i18n import JavaScriptCatalog
 ...
 ```
 
-### NEW
+#### NEW
 - Added allink_quote plugin
 - Added browser-check translations
 
 ## v2.2.3
-### IMPORTANT
+#### IMPORTANT
 We added the django_cleanup package
 This will delete a file on the filesystem, when a file gets deleted in the django-filer media library.
 It does not however delete for example the preview_image on the filesystem if a News entry gets deleted (we also do not delete the filer image/file instance in that case.)
 ###### REQUIREMENTS
 - added django-cleanup==2.1.0
-### NEW
+#### NEW
 - Added hrefLang to Sitemap [#11](https://github.com/allink/allink-core/pull/11)
     - activate feature for CMS Pages: register `sitemaps = {'cms': CMSHrefLangSitemap}` in project urls.py
     - activate feature for App Detailview: register `class AppName(HrefLangSitemap):` in sitemaps.py in every app
-### FIXES
+#### FIXES
 - fixed fork_app and new_app command [#17](https://github.com/allink/allink-core/pull/17)
 - moved language choices from legacylinks models to forms, so no "shadow" migrations will be created on client projects [#12](https://github.com/allink/allink-core/pull/12)
 - readded accidentially removed restrictions for news admin lead field
 
 ## v2.2.2
-### IMPORTANT
+#### IMPORTANT
 We removed aldryn-common as a dependency as this will no longer be maintained. Replace every occurence of 'aldryn_common' in your project (inlcuding migration files).
 Search for: 'aldryn_common.admin_fields.sortedm2m' and replace with 'allink_core.core.models.fields'
 ###### REQUIREMENTS
 - removed aldryn-common (deinstall the divio addon in th control panel)
 - added django-sortedm2m==2.0.0
-### NEW
+#### NEW
 - added sortedm2m model fields to core
 
 ## v2.2.1
@@ -67,47 +71,47 @@ Search for: 'aldryn_common.admin_fields.sortedm2m' and replace with 'allink_core
 - refactored customisation commands for new_app and fork_app
 
 ## v2.2.0
-### IMPORTANT
+#### IMPORTANT
 - UPDATE REQUIRED: [allink-core-static v2.2.0](https://github.com/allink/allink-core-static/blob/v2.2.0/CHANGELOG.md)
 ## NEW
 - Video-Plugin:
     - Added autoplay option for mobile devices
 
 ## v2.1.0
-### IMPORTANT
+#### IMPORTANT
 - UPDATE REQUIRED: [allink-core-static v2.1.0](https://github.com/allink/allink-core-static/blob/v2.1.0/CHANGELOG.md)
 
 ## v2.0.8
-### IMPORTANT
+#### IMPORTANT
 - Required update: [allink-core-static](https://github.com/allink/allink-core-static/commit/1190bda8b5dc38add612be8acb3cb77cfddbc1f6)
-### FIXES
+#### FIXES
 - Cleanup and new elements in styleguide template
 - Updated buttons markup in testimonial, app content load more and browser-check templates
 
 ## v2.0.7
-### FIXES
+#### FIXES
 - Re-added missing base template markup
 
 ## v2.0.6
-### FIXES
+#### FIXES
 - Re-added missing base template markup
 - Properly render og tags of app-detail views
 
 ## v2.0.5
-### NEW
+#### NEW
 - refactored buttons: introduced link partial templates, updated other templates accordingly
 - added new project setting `BUTTON_CONTEXT_CHOICES`
 - removed a lot of template logic from button-link-plugin link template
 - removed allink_quote plugin
 
 ## v2.0.2
-### NEW
+#### NEW
 - removed TransactionTestCase and CMSTransactionTestCase where not needed
 - removed filter_fields from appcontent plugin
 - removed filters param from get_render_queryset_for_display
 - moved select manual entries to get_render_queryset_for_display
 
 ## v2.0.1
-### NEW
+#### NEW
 - admin and plugins are no longer translated, we removed every translated string from the admin. This should make translation of the customer specific frontend relevant fields easier.
 - The favicon set is now added with an include rather than rendered with a templatetag.

--- a/allink_core/core/allink_settings.py
+++ b/allink_core/core/allink_settings.py
@@ -35,7 +35,6 @@ ALLINK_INSTALLED_APPS = [
     'django_countries',
     'django.contrib.postgres',
     'inline_static',
-    'django_cleanup',
 
     # allink core apps
     'allink_core.core',

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -43,4 +43,3 @@ geopy==1.19.0
 reportlab==3.5.20
 beautifulsoup4==4.7.1
 lxml==4.4.1
-django-cleanup==2.1.0


### PR DESCRIPTION
We experienced some rather strange behaviour in production in connecting with django db_cache.("cannot deepcopy this pattern object")
