### PR TITLE
Update logic for alt text on images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ general bugfixes
 - Wrapped slider plugin to prevent spacings [#100](https://github.com/allink/allink-core/pull/100)
 - Whole area is now clickable on all teasers, added new include/_button.html snippet which is used [#104](https://github.com/allink/allink-core/pull/104)
 - Updated locations detail template [#106](https://github.com/allink/allink-core/pull/106)
-- SEO accordion plugin now has 'Enable SEO FAQ schema' option to add schema.org compliant markup  [#108](https://github.com/allink/allink-core/pull/108)
+- SEO accordion plugin now has 'Enable SEO FAQ schema' option to add schema.org compliant markup [#108](https://github.com/allink/allink-core/pull/108)
+- Updated logic for alt text on images [#110](https://github.com/allink/allink-core/pull/110)
 
 #### FIXES
 - Fixed translation for outdated modal [#99](https://github.com/allink/allink-core/pull/99)

--- a/allink_core/core/templates/templatetags/allink_image.html
+++ b/allink_core/core/templates/templatetags/allink_image.html
@@ -35,8 +35,9 @@
             {% if lazyload_enabled %}data-{% endif %}srcset="{{thumbnail_xs.url}}, {{thumbnail_xs.high_resolution.url}} 2x"
             {% if lazyload_enabled %}srcset="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="{% endif %}
             src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
-            {% if instance.picture.label and not instance.attributes.alt %} alt="{{ instance.picture.label }}"
-            {% elif alt_text and not instance.picture.label and not instance.attributes.alt %}alt="{{ alt_text }}"{% endif %}
+            {% if alt_text %}alt="{{ alt_text }}"
+            {% elif instance.picture.default_alt_text %}alt="{{ instance.picture.default_alt_text }}"
+            {% elif instance.picture.name %}alt="{{ instance.picture.name }}"{% endif %}
             {{ instance.attributes_str }}
         >
 


### PR DESCRIPTION
New logic for alt texts in the image plugin with the following priority:

1. Variable alt_text that gets passed from a template (e.g. teaser)
2. Default alt text from media library
3. Image name from media library