### PR TITLE
Move noscript part of tag manager to body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ general bugfixes
 - Removed contact migration [#125](https://github.com/allink/allink-core/pull/125) 
     - if you upgrade an existing project with this the contact migration file will not be deleted
 - Hide inactive elements in sitemap [#132](https://github.com/allink/allink-core/pull/132)
+- Moved noscript part of tag manager to body [#133](https://github.com/allink/allink-core/pull/133)
     
 #### DATA MIGRATIONS
 - Added custom link option for pagination button on content plugins [~~#118~~(reverted)](https://github.com/allink/allink-core/pull/118) [#124](https://github.com/allink/allink-core/pull/124)

--- a/allink_core/core/templates/allink_core/base_root.html
+++ b/allink_core/core/templates/allink_core/base_root.html
@@ -64,13 +64,17 @@
 
     {{ ALDRYN_SNAKE.render_head }}
 
-    {# Google Tag Manager (hide when in edit mode #}
+    {# Google Tag Manager (hide when in edit mode) #}
     {% if not request.toolbar.show_toolbar %}
-    {% google_tag_manager %}
+        {% google_tag_manager %}
     {% endif %}
 </head>
 
 <body id="page-top" class="noscript lang-{{ LANGUAGE_CODE }} {% block body_class %}tpl-root{% endblock %}" {% block body_additional_attributes %}{% endblock body_additional_attributes %}>
+    {# Google Tag Manager (noscript part must be in body) #}
+    {% if not request.toolbar.show_toolbar %}
+        <noscript><iframe src="//www.googletagmanager.com/ns.html?id={{ tag_id }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    {% endif %}
 
     {% block skip_links %}
         {# Accessibility: Make sure the anchor IDs are up-to-date #}


### PR DESCRIPTION
Copy the following JavaScript and paste it as close to the opening <head> tag as possible on every page of your website.

Copy the following snippet and paste it immediately after the opening <body> tag on every page of your website

https://developers.google.com/tag-manager/quickstart